### PR TITLE
Add personal details to portfolio

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,12 @@
   <nav>
     <div class="nav-left">
       <span id="themeToggle">🌙</span>
+      <a href="#intro-text">Intro</a>
+      <a href="#about">About</a>
       <a href="#planning">기획</a>
       <a href="#develop">개발</a>
-      <a href="#sound">사운드</a>
-      <a href="#art">아트</a>
+      <a href="#art">디자인</a>
+      <a href="#etc">기타</a>
     </div>
     <div class="nav-right">
       <input type="text" id="searchInput" placeholder="검색어 입력...">
@@ -36,24 +38,70 @@
         <p class = "gradient-text">상상하고 구현하는 사람</p>
       </div>
     </div>
-    <div class="scroll-arrow">↓</div>
+  <div class="scroll-arrow">↓</div>
+  </section>
+
+  <section id="etc" class="fade-section">
+    <h2 class="section-title">ETC</h2>
+    <div class="experience-block">
+      <div class="item"><img src="https://via.placeholder.com/40" alt="venture"><p><strong>KU-벤처</strong> 멤버</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="edge"><p><strong>EDGE</strong> 회계부</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="makers"><p><strong>메이커스팜</strong> 크루원</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="tutor"><p><strong>EDGE</strong> 개발 튜터</p></div>
+    </div>
+    <p class="etc-foot">개발은 즐겁다. 아직 많이 배우는 입장이지만, 그만큼 누구보다 열정적이고 빠르게 움직일 준비가 되어 있습니다🏃🏻‍♂️</p>
+  </section>
+
+  <section id="intro-text" class="fade-section">
+    <h2 class="section-title">Intro</h2>
+    <p>안녕하세요🙌🏻 이번 KUIT <strong>5기 WEB</strong> 파트이자, 지난 KUIT <strong>4기 PM</strong> 파트를 맡았던 이지환입니다.</p>
+    <p>저에게는 크게 <strong>두가지 목표</strong>가 있습니다. 장기적으로는 빠르고 편리한 것뿐만 아니라 하루하루를 설레게 만들고 <strong>일상의 범위를 넓혀</strong>줄 수 있는 <strong>서비스를 운영</strong>하는 것입니다.</p>
+    <p>단기적인 목표는 올해 하반기까지 서비스를 <strong>직접 출시한 후, 피드백을 받아 개선하면서 실제 성과와 성장으로 이어지는 경험</strong>을 쌓는 것입니다.</p>
+    <p>이를 위해 <strong>KUIT WEB, 웹프로그래밍, 데이터베이스</strong> 수업을 병행하며 <strong>React, TypeScript, HTML/CSS</strong> 등 FE 기본 기술들을 익혔고, 이제는 함께 서비스를 만들어나갈 분을 찾고 있습니다.</p>
+  </section>
+
+  <section id="about" class="fade-section">
+    <h2 class="section-title">About Me</h2>
+    <ul>
+      <li><a href="https://github.com/Konkuk-KUIT/KUIT5_WEB-Frontend">KUIT Web 5th</a></li>
+      <li>건국대학교 컴퓨터공학부 24</li>
+    </ul>
+  </section>
+
+  <section id="contact" class="fade-section">
+    <h2 class="section-title">Contact</h2>
+    <ul>
+      <li>📞 010-5818-3791</li>
+      <li>✉️ <a href="mailto:mire090909@gmail.com">mire090909@gmail.com</a></li>
+      <li><a href="https://github.com/Hwanji2">GitHub: Hwanji2</a></li>
+      <li><a href="https://www.instagram.com/hwanji.2">Instagram</a></li>
+    </ul>
   </section>
 
   <!-- Sections -->
   <section id="planning" class="fade-section">
     <h2 class="section-title red">기획</h2>
     <div class="experience-block">
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>BARO</strong> – 시간·장소 조율 (PM)</p></div>
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>도란도란</strong> – 음성 기반 AI 힐링 메타버스</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="book"><p><strong>자가출판</strong> 및 ISBN 발급</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="booth"><p><strong>새맞주 부스</strong> 전시 출품 및 운영 (24-2, 25-1)</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="share"><p><strong>러닝앤쉐어링</strong> 팀장</p></div>
     </div>
   </section>
 
   <section id="develop" class="fade-section">
     <h2 class="section-title blue">개발</h2>
     <div class="experience-block">
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>러닝타임</strong> – 우리는 왜 달리는가?</p></div>
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>whoamI</strong> – 미스터리 비주얼 노벨</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="web"><p><strong>React, TypeScript</strong> 기반 웹 서비스 개발</p></div>
+      <div class="item"><img src="https://via.placeholder.com/40" alt="project"><p><strong>프로젝트 모음</strong> – <a href="https://www.notion.so/20651bc8e7df80649be3e91be8126689?pvs=21">Notion</a></p></div>
     </div>
+    <table class="skill-table">
+      <tr><th>JS</th><td>★★★★☆</td></tr>
+      <tr><th>TS</th><td>★★★☆☆</td></tr>
+      <tr><th>Java</th><td>★★★★☆</td></tr>
+      <tr><th>C#</th><td>★★★★☆</td></tr>
+      <tr><th>C++</th><td>★★★☆☆</td></tr>
+      <tr><th>Dart</th><td>★★☆☆☆</td></tr>
+    </table>
   </section>
 
   <section id="sound" class="fade-section">
@@ -65,19 +113,22 @@
   </section>
 
   <section id="art" class="fade-section">
-    <h2 class="section-title gold">아트</h2>
-    <div class="experience-block">
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>ClipStudio</strong> – 굿즈 디자인</p></div>
-      <div class="item"><img src="https://via.placeholder.com/40"><p><strong>Blender</strong> – 3D 모델링</p></div>
-    </div>
+    <h2 class="section-title gold">디자인</h2>
+    <table class="skill-table">
+      <tr><th>Figma</th><td>★★★☆☆</td></tr>
+      <tr><th>Notion</th><td>★★★☆☆</td></tr>
+      <tr><th>Fmod</th><td>★★☆☆☆</td></tr>
+      <tr><th>Clip Studio Paint</th><td>★★☆☆☆</td></tr>
+      <tr><th>Blender</th><td>★☆☆☆☆</td></tr>
+    </table>
   </section>
 
-  <footer>
-    <p>Contact: leejihwan.dev@gmail.com</p>
+  <footer id="contact">
+    <p>✉️ <a href="mailto:mire090909@gmail.com">mire090909@gmail.com</a></p>
+    <p>📞 010-5818-3791</p>
     <p>
-      <a href="#">GitHub</a>
-      <a href="#">Notion</a>
-      <a href="#">LinkedIn</a>
+      <a href="https://github.com/Hwanji2">GitHub</a>
+      <a href="https://www.instagram.com/hwanji.2">Instagram</a>
     </p>
     <p>&copy; 2025 이지환. All rights reserved.</p>
   </footer>

--- a/style.css
+++ b/style.css
@@ -302,3 +302,25 @@ body.light footer a {
 body.light footer a:hover {
   text-decoration: underline;
 }
+
+/* 스킬 테이블 */
+.skill-table {
+  width: 100%;
+  margin-top: 20px;
+  border-collapse: collapse;
+}
+.skill-table th,
+.skill-table td {
+  border: 1px solid #666;
+  padding: 6px 10px;
+  text-align: left;
+}
+body.light .skill-table th,
+body.light .skill-table td {
+  border-color: #ccc;
+}
+
+.etc-foot {
+  margin-top: 20px;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- integrate intro, about, contact and miscellaneous sections
- update planning, development and design sections with profile info
- restyle footer and add skill table styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68433fb4b03c8327a267d630cbe2b09d