### PR TITLE
Enhance planning book view and calculator layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
   <!-- Sections -->
   <section id="planning" class="fade-section">
     <h2 class="section-title red">기획</h2>
-    <div class="planning-pages">
+    <div id="book" class="book">
       <div class="page active">
         <div class="item"><img src="https://via.placeholder.com/40" alt="book"><p><strong>자가출판</strong> 및 ISBN 발급</p></div>
       </div>
@@ -85,10 +85,6 @@
       <div class="page">
         <div class="item"><img src="https://via.placeholder.com/40" alt="share"><p><strong>러닝앤쉐어링</strong> 팀장</p></div>
       </div>
-    </div>
-    <div class="page-controls">
-      <button id="prevPage">이전</button>
-      <button id="nextPage">다음</button>
     </div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -56,22 +56,31 @@ document.querySelectorAll('.dev-tabs button').forEach(btn => {
 });
 
 // 기획 페이지 넘기기
-const pages = document.querySelectorAll('#planning .page');
+const book = document.getElementById('book');
+const pages = book ? book.querySelectorAll('.page') : [];
 let pageIndex = 0;
-if (pages.length) {
-  const prev = document.getElementById('prevPage');
-  const next = document.getElementById('nextPage');
-  const show = idx => {
-    pages.forEach(p => p.classList.remove('active'));
-    pages[idx].classList.add('active');
+if (book && pages.length) {
+  const show = (idx, dir) => {
+    const current = pages[pageIndex];
+    const nextIdx = (idx + pages.length) % pages.length;
+    const next = pages[nextIdx];
+    current.classList.remove('active');
+    current.classList.add(dir === 'next' ? 'flip-next-out' : 'flip-prev-out');
+    next.classList.add('active', dir === 'next' ? 'flip-next-in' : 'flip-prev-in');
+    setTimeout(() => {
+      current.classList.remove('flip-next-out', 'flip-prev-out');
+      next.classList.remove('flip-next-in', 'flip-prev-in');
+    }, 600);
+    pageIndex = nextIdx;
   };
-  prev.addEventListener('click', () => {
-    pageIndex = (pageIndex - 1 + pages.length) % pages.length;
-    show(pageIndex);
-  });
-  next.addEventListener('click', () => {
-    pageIndex = (pageIndex + 1) % pages.length;
-    show(pageIndex);
+
+  book.addEventListener('click', e => {
+    const rect = book.getBoundingClientRect();
+    if (e.clientX - rect.left < rect.width / 2) {
+      show(pageIndex - 1, 'prev');
+    } else {
+      show(pageIndex + 1, 'next');
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -281,10 +281,35 @@ body.light .fade-section {
 .dev-tabs button {
   padding: 6px 12px;
   cursor: pointer;
+  border: none;
+  border-radius: 6px;
+  background: linear-gradient(45deg, #3399ff, #66ccff);
+  color: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  transition: transform 0.2s;
+}
+.dev-tabs button:hover {
+  transform: translateY(-2px);
 }
 .dev-content { display: none; margin-top: 20px; }
 .dev-content.active { display: block; }
-.calc-buttons button { width: 40px; height: 40px; margin: 2px; }
+.calc-buttons {
+  display: grid;
+  grid-template-columns: repeat(4, 50px);
+  gap: 5px;
+  justify-content: center;
+  margin-top: 10px;
+}
+.calc-buttons button {
+  width: 50px;
+  height: 50px;
+  border: none;
+  border-radius: 4px;
+  background: #333;
+  color: #fff;
+  font-size: 1rem;
+}
+.calc-buttons button:hover { background: #555; }
 .video-wrapper { margin-top: 20px; display: flex; gap: 10px; flex-wrap: wrap; }
 .audio-player { margin-top: 20px; }
 .item {
@@ -362,17 +387,46 @@ body.light .skill-table td {
 }
 
 /* Planning pages */
-.planning-pages {
+.book {
   position: relative;
-  min-height: 60px;
-}
-.page { display: none; }
-.page.active { display: block; }
-.page-controls { text-align: center; margin-top: 10px; }
-.page-controls button {
-  padding: 4px 12px;
-  margin: 0 5px;
+  width: 300px;
+  height: 180px;
+  margin: 20px auto;
+  perspective: 1000px;
   cursor: pointer;
+}
+.page {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  color: #000;
+  border-radius: 6px;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  padding: 20px;
+  backface-visibility: hidden;
+  display: none;
+}
+.page.active { display: block; }
+.page.flip-next-out { animation: flipNextOut 0.6s forwards; }
+.page.flip-next-in { animation: flipNextIn 0.6s forwards; }
+.page.flip-prev-out { animation: flipPrevOut 0.6s forwards; }
+.page.flip-prev-in { animation: flipPrevIn 0.6s forwards; }
+
+@keyframes flipNextOut {
+  from { transform: rotateY(0); }
+  to { transform: rotateY(-180deg); }
+}
+@keyframes flipNextIn {
+  from { transform: rotateY(180deg); }
+  to { transform: rotateY(0); }
+}
+@keyframes flipPrevOut {
+  from { transform: rotateY(0); }
+  to { transform: rotateY(180deg); }
+}
+@keyframes flipPrevIn {
+  from { transform: rotateY(-180deg); }
+  to { transform: rotateY(0); }
 }
 
 /* Simple runner game */


### PR DESCRIPTION
## Summary
- rework planning section into a clickable book
- animate page flips using CSS and JS
- display calculator buttons in a grid
- style dev tabs for consistent appearance

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68434cd1337c83279d8566169dfdc1e7