### PR TITLE
Improve game obstacles and audio UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,8 @@
       <button data-target="calc">계산기</button>
     </div>
     <div id="game" class="dev-content">
-      <canvas id="gameCanvas" width="300" height="150"></canvas>
-      <p class="game-instr">스페이스바로 점프!</p>
+      <canvas id="gameCanvas" width="360" height="160"></canvas>
+      <p class="game-instr">스페이스바로 점프! 세로 글자를 피해보세요</p>
     </div>
     <div id="obj3d" class="dev-content">
       <canvas id="cubeCanvas" width="300" height="200"></canvas>

--- a/script.js
+++ b/script.js
@@ -93,6 +93,7 @@ if (document.getElementById('gameCanvas')) {
     .filter(t => t.length > 0 && t.length < 15);
   const player = { x: 30, y: 110, w: 20, h: 20, vy: 0, sliding: false };
   const obstacles = [];
+  const fontSize = 24;
   let frame = 0;
   let score = 0;
   let best = parseInt(localStorage.getItem('highscore') || '0');
@@ -100,9 +101,10 @@ if (document.getElementById('gameCanvas')) {
   function spawn() {
     const high = Math.random() < 0.5;
     const text = texts[Math.floor(Math.random() * texts.length)] || 'TXT';
-    ctx.font = '16px sans-serif';
-    const w = ctx.measureText(text).width + 10;
-    obstacles.push({ x: canvas.width, y: high ? 80 : 120, w, h: 20, text });
+    ctx.font = fontSize + 'px sans-serif';
+    const h = fontSize * text.length;
+    const base = high ? 70 : 110;
+    obstacles.push({ x: canvas.width, y: base - h, w: fontSize, h, text });
   }
 
   document.addEventListener('keydown', e => {
@@ -145,7 +147,12 @@ if (document.getElementById('gameCanvas')) {
     ctx.fillRect(player.x, player.y, player.w, player.h);
     ctx.fillStyle = '#ff5555';
     obstacles.forEach(o => {
-      ctx.fillText(o.text, o.x, o.y);
+      ctx.save();
+      ctx.font = fontSize + 'px sans-serif';
+      for (let i = 0; i < o.text.length; i++) {
+        ctx.fillText(o.text[i], o.x, o.y + fontSize * (i + 1));
+      }
+      ctx.restore();
     });
     ctx.fillStyle = '#000';
     ctx.fillText('Score: ' + score + '  Best: ' + best, 10, 10);

--- a/style.css
+++ b/style.css
@@ -430,8 +430,9 @@ body.light .skill-table td {
 
 /* Simple runner game */
 #gameCanvas {
-  background: #f0f0f0;
-  border: 1px solid #ccc;
+  background: linear-gradient(#e8f4ff, #bcd4ff);
+  border: 1px solid #8ab4f8;
+  border-radius: 4px;
 }
 .game-instr { margin-top: 5px; font-size: 0.9rem; }
 
@@ -470,6 +471,27 @@ body.light .progress-bar-audio { background: #b5d7b5; }
 }
 #playPause:hover, #prevTrack:hover, #nextTrack:hover {
   background: #3a8b3a;
+}
+.audio-player input[type=range] {
+  -webkit-appearance: none;
+  width: 80px;
+  height: 4px;
+  background: #6eba6e;
+  border-radius: 4px;
+}
+.audio-player input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  background: #4caf50;
+  border-radius: 50%;
+  cursor: pointer;
+}
+body.light .audio-player input[type=range] {
+  background: #c8eac8;
+}
+body.light .audio-player input[type=range]::-webkit-slider-thumb {
+  background: #5cbf5c;
 }
 .playlist {
   list-style: none;


### PR DESCRIPTION
## Summary
- make the mini game show vertical text obstacles
- enlarge the game canvas and tweak its styling
- style audio volume sliders with a green theme

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843517966c08327a78c4b897c958947