### PR TITLE
Enhance mini-games and add reaction challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,12 +113,16 @@
         <div class="game-area">
           <canvas id="gameCanvas" width="360" height="160"></canvas>
           <div id="cardGame" class="overlay hidden">
+            <div id="cardStartMsg" class="start-msg">아무 곳이나 누르면 시작</div>
             <div id="cardTimer" class="timer"></div>
             <div id="cardGrid" class="card-grid"></div>
           </div>
           <div id="linePuzzle" class="overlay hidden">
             <div id="lineTimer" class="timer"></div>
             <canvas id="lineCanvas" width="360" height="160"></canvas>
+          </div>
+          <div id="reactionGame" class="overlay hidden">
+            <div id="reactionMsg" class="start-msg">화면이 빨개지면 클릭!</div>
           </div>
           <div id="gameOver" class="game-over hidden">
             <div id="finalScore"></div>

--- a/style.css
+++ b/style.css
@@ -525,6 +525,10 @@ body.light .overlay {
   color: #87ceeb;
 }
 .overlay.hidden { display: none; }
+.start-msg {
+  margin-bottom: 10px;
+}
+#lineTimer { display: none; }
 .card-grid {
   display: grid;
   grid-template-columns: repeat(4, 60px);


### PR DESCRIPTION
## Summary
- preview cards before memory game starts
- show card start message and move line puzzle timer into canvas
- award score for card matches
- add new reaction mini-game triggered after score 10
- reset new states on restart

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684440b809b48327aca4e917cd918396