### PR TITLE
Add tower intro to running game

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,11 @@
       <div class="game-wrapper">
         <div class="game-area">
           <canvas id="gameCanvas" width="360" height="160"></canvas>
+          <div id="towerIntro" class="overlay hidden">
+            <canvas id="introCanvas" width="360" height="160"></canvas>
+            <div id="introMsg" class="start-msg"></div>
+            <button id="startTowerBtn" class="hidden">탑 오르기</button>
+          </div>
           <div id="cardGame" class="overlay hidden">
             <div id="cardStartMsg" class="start-msg">아무 곳이나 누르면 시작</div>
             <div id="cardGrid" class="card-grid"></div>

--- a/style.css
+++ b/style.css
@@ -516,6 +516,7 @@ body.light .score-block {
   align-items: center;
 }
 .game-over button { margin-top: 10px; padding: 6px 12px; }
+.overlay #startTowerBtn { margin-top: 10px; padding: 6px 12px; }
 .game-over.hidden { display: none; }
 .game-instr { margin-top: 5px; font-size: 0.9rem; }
 
@@ -583,6 +584,8 @@ body.light .card-grid .card { background: #fff; border-color: #87ceeb; }
 }
 #lineCanvas { background: #111; border: 1px solid #87ceeb; }
 body.light #lineCanvas { background: #eee; border-color: #87ceeb; }
+#introCanvas { background: #111; border: 1px solid #87ceeb; margin-bottom: 10px; }
+body.light #introCanvas { background: #eee; border-color: #87ceeb; }
 
 .shake {
   animation: shake 0.3s;


### PR DESCRIPTION
## Summary
- add `towerIntro` overlay with NPC greeting
- style intro canvas and start button
- implement tower intro logic in script
- start game with tower intro and track visit count

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6845bf684a84832794ff0b410326d1d3