### PR TITLE
Fix tower intro layout and start button logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -542,6 +542,7 @@ if (document.getElementById('gameCanvas')) {
       towerIntroEl.classList.add('hidden');
       introActive = false;
       running = true;
+      update();
     });
   }
 

--- a/style.css
+++ b/style.css
@@ -516,7 +516,13 @@ body.light .score-block {
   align-items: center;
 }
 .game-over button { margin-top: 10px; padding: 6px 12px; }
-.overlay #startTowerBtn { margin-top: 10px; padding: 6px 12px; }
+.overlay #startTowerBtn {
+  position: absolute;
+  left: 50%;
+  bottom: 10px;
+  transform: translateX(-50%);
+  padding: 6px 12px;
+}
 .game-over.hidden { display: none; }
 .game-instr { margin-top: 5px; font-size: 0.9rem; }
 
@@ -542,7 +548,7 @@ body.light .overlay {
 #introMsg {
   position: absolute;
   left: 50%;
-  bottom: 10px;
+  bottom: 60px;
   transform: translateX(-50%);
   max-width: 90%;
   padding: 8px 12px;
@@ -557,9 +563,11 @@ body.light #introMsg {
 #introOptions {
   position: absolute;
   left: 50%;
-  bottom: 40px;
+  bottom: 10px;
   transform: translateX(-50%);
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 6px;
 }
 #cardStartMsg {


### PR DESCRIPTION
## Summary
- keep start button inside canvas overlay
- move intro dialog higher and options to the bottom
- trigger game loop when starting the tower

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845c600b0b48327912810974991efa6