### PR TITLE
Remove extra mini-games

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,23 +112,6 @@
       <div class="game-wrapper">
         <div class="game-area">
           <canvas id="gameCanvas" width="480" height="200"></canvas>
-          <div id="towerIntro" class="overlay hidden">
-            <canvas id="introCanvas" width="480" height="200"></canvas>
-            <div id="introMsg" class="start-msg"></div>
-            <div id="introOptions" class="options hidden"></div>
-            <button id="startTowerBtn" class="hidden">탑 오르기</button>
-          </div>
-          <div id="cardGame" class="overlay hidden">
-            <div id="cardStartMsg" class="start-msg">아무 곳이나 누르면 시작</div>
-            <div id="cardGrid" class="card-grid"></div>
-          </div>
-          <div id="linePuzzle" class="overlay hidden">
-            <div id="lineTimer" class="timer"></div>
-            <canvas id="lineCanvas" width="480" height="200"></canvas>
-          </div>
-          <div id="reactionGame" class="overlay hidden">
-            <div id="reactionMsg" class="start-msg">화면이 빨개지면 클릭!</div>
-          </div>
           <div id="gameOver" class="game-over hidden">
             <div id="finalScore"></div>
             <button id="restartBtn">다시 시작</button>
@@ -138,7 +121,6 @@
           <div id="scoreDisplay" class="score-display"></div>
           <div class="heart-row">
             <div id="heartContainer" class="heart-container"></div>
-            <div id="cardTimer" class="timer hidden"></div>
           </div>
           <div id="inventory" class="inventory"></div>
         </div>


### PR DESCRIPTION
## Summary
- cut tower intro and mini-game overlays so only the runner remains
- start the runner when the "점수 게임" tab is clicked
- add background trees and dynamic canvas effects
- toggle page theme and canvas width based on score

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7bcc96c8327bedd6b86c30f874e