### PR TITLE
Enhance game visuals and limit intro square

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,7 @@
     <div id="game" class="dev-content">
       <div class="game-wrapper">
         <div class="game-area">
+          <pre id="codeBg"></pre>
           <canvas id="gameCanvas" class="collapsed" width="480" height="200"></canvas>
           <div id="gameOver" class="game-over hidden">
             <div id="finalScore"></div>

--- a/style.css
+++ b/style.css
@@ -297,6 +297,7 @@ body.light .section-title:not(.red):not(.blue):not(.green):not(.gold) {
   background: #87ceeb;
   border: 2px solid #333;
   cursor: pointer;
+  box-shadow: 0 0 6px #87ceeb;
 }
 .calc-buttons {
   display: grid;
@@ -449,6 +450,18 @@ body.light .skill-table td {
   perspective: 600px;
 }
 .game-area { position: relative; }
+#codeBg {
+  position: absolute;
+  inset: 0;
+  padding: 4px;
+  color: #87ceeb;
+  opacity: 0.1;
+  font-size: 10px;
+  font-family: monospace;
+  white-space: pre-wrap;
+  pointer-events: none;
+  overflow: hidden;
+}
 #gameCanvas {
   background: radial-gradient(#011, #000);
   border: 1px solid #87ceeb;


### PR DESCRIPTION
## Summary
- keep intro square within the develop section and delay its start
- add glowing effect to start square
- create code typing background behind the game canvas
- add subtle glow to player, texts and emoji in runner game
- randomly shift and scale the canvas every 30 score points

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845d2996bec8327b23d6840d7ce49bd