### PR TITLE
Enhance runner game interactions

### DIFF
--- a/script.js
+++ b/script.js
@@ -327,6 +327,11 @@ if (document.getElementById('gameCanvas')) {
       span.textContent = '💙';
       heartContainer.appendChild(span);
     }
+    if (hearts === 1) {
+      heartContainer.classList.add('low');
+    } else {
+      heartContainer.classList.remove('low');
+    }
   }
   function updateScore() {
     if (score > best) { best = score; localStorage.setItem("highscore", best); }
@@ -654,12 +659,29 @@ if (document.getElementById('gameCanvas')) {
   canvas.style.touchAction = 'none';
   let startY = null;
   let touchHeld = false;
+  let dragTriggered = false;
   canvas.addEventListener('pointerdown', e => {
     startY = e.clientY;
     touchHeld = true;
+    dragTriggered = false;
+  });
+  canvas.addEventListener('pointermove', e => {
+    if (startY !== null && !dragTriggered) {
+      const dy = e.clientY - startY;
+      if (dy > 30) {
+        dragTriggered = true;
+        if (player.y >= 110) {
+          player.sliding = true;
+          player.h = 10;
+          player.y = 120;
+        } else {
+          player.vy = Math.max(player.vy, 8);
+        }
+      }
+    }
   });
   canvas.addEventListener('pointerup', e => {
-    if (startY !== null) {
+    if (startY !== null && !dragTriggered) {
       const dy = e.clientY - startY;
       if (dy > 30) {
         if (player.y >= 110) {
@@ -687,6 +709,7 @@ if (document.getElementById('gameCanvas')) {
     touchHeld = false;
     jumpActive = false;
     startY = null;
+    dragTriggered = false;
   });
 
   function endGame() {
@@ -844,7 +867,12 @@ if (document.getElementById('gameCanvas')) {
     ctx.save();
     ctx.shadowColor = '#87ceeb';
     ctx.shadowBlur = glow;
-    trees.forEach(t => { ctx.save(); ctx.globalAlpha = 0.5; ctx.fillText(t.emoji, t.x, t.y); ctx.restore(); });
+    trees.forEach(t => {
+      ctx.save();
+      ctx.globalAlpha = shiftDown ? 0.5 : 1;
+      ctx.fillText(t.emoji, t.x, t.y);
+      ctx.restore();
+    });
     ctx.fillStyle = '#3399ff';
     ctx.fillRect(player.x, player.y, player.w, player.h);
     ctx.fillStyle = '#ff5555';

--- a/style.css
+++ b/style.css
@@ -531,6 +531,13 @@ body.light .score-block {
   color: #3399ff;
   filter: drop-shadow(0 0 4px #3399ff);
 }
+.heart-container.low .heart {
+  animation: heart-glow 1s infinite;
+}
+@keyframes heart-glow {
+  0% { filter: drop-shadow(0 0 2px #3399ff); opacity: 0.5; }
+  100% { filter: drop-shadow(0 0 8px #3399ff); opacity: 1; }
+}
 .heart.fall { animation: heart-fall 0.6s forwards; }
 @keyframes heart-fall {
   to { transform: translateY(20px); opacity: 0; }
@@ -546,7 +553,19 @@ body.light .score-block {
   justify-content: center;
   align-items: center;
 }
-.game-over button { margin-top: 10px; padding: 6px 12px; }
+.game-over button {
+  margin-top: 10px;
+  padding: 6px 12px;
+  font-family: 'Press Start 2P', monospace;
+  background: #111;
+  color: #87ceeb;
+  border: 2px solid #87ceeb;
+  border-radius: 2px;
+  cursor: pointer;
+}
+body.light .game-over button {
+  background: #fff;
+}
 .overlay #startTowerBtn {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
## Summary
- add pulsing glow when only one heart remains
- make emoji opacity react to shift key
- trigger slide/fast fall on downward drag
- restyle game-over button to match pixel art

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6845e6e7b6e48327a5c66fbe856e32a3