### PR TITLE
Improve audio player layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,23 +132,30 @@
       <div class="item"><img src="https://via.placeholder.com/40"><p><strong>SynthV</strong> – AI보컬 믹싱</p></div>
     </div>
     <div class="audio-player">
-      <canvas id="waveform" width="300" height="60"></canvas>
-      <audio id="audio"></audio>
-      <button id="prevTrack">⏮</button>
-      <button id="playPause">▶</button>
-      <button id="nextTrack">⏭</button>
-      <div class="progress-bar-audio"><div class="progress"></div></div>
-      <div class="controls">
-        <input type="range" id="masterVolume" min="0" max="1" step="0.01" value="1">
-        L <input type="range" id="leftVolume" min="0" max="1" step="0.01" value="1">
-        R <input type="range" id="rightVolume" min="0" max="1" step="0.01" value="1">
+      <div class="player-upper">
+        <img id="albumArt" class="album-art" src="https://via.placeholder.com/80" alt="album" />
+        <div class="volume-controls">
+          <input type="range" id="masterVolume" min="0" max="1" step="0.01" value="1">
+          <div class="lr-volume">
+            L <input type="range" id="leftVolume" min="0" max="1" step="0.01" value="1">
+            R <input type="range" id="rightVolume" min="0" max="1" step="0.01" value="1">
+          </div>
+        </div>
       </div>
+      <canvas id="waveform" width="280" height="60"></canvas>
+      <div class="progress-bar-audio"><div class="progress"></div></div>
+      <div class="control-buttons">
+        <button id="prevTrack">⏮</button>
+        <button id="playPause">▶</button>
+        <button id="nextTrack">⏭</button>
+      </div>
+      <audio id="audio"></audio>
     </div>
     <h3 class="album-title">Track List</h3>
     <ul class="playlist">
-      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3" class="active">Track 1</li>
-      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3">Track 2</li>
-      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3">Track 3</li>
+      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3" data-img="https://via.placeholder.com/80?text=1" class="active">Track 1</li>
+      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3" data-img="https://via.placeholder.com/80?text=2">Track 2</li>
+      <li data-src="https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3" data-img="https://via.placeholder.com/80?text=3">Track 3</li>
     </ul>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -986,12 +986,15 @@ if (audio) {
   const waveCtx = waveform ? waveform.getContext('2d') : null;
   const list = document.querySelectorAll('.playlist li');
   const tracks = Array.from(list).map(li => li.dataset.src);
+  const imgs = Array.from(list).map(li => li.dataset.img);
+  const albumImg = document.getElementById('albumArt');
   let trackIndex = 0;
   function load(i) {
     trackIndex = (i + tracks.length) % tracks.length;
     audio.src = tracks[trackIndex];
     list.forEach(li => li.classList.remove('active'));
     list[trackIndex].classList.add('active');
+    if (albumImg) albumImg.src = imgs[trackIndex];
     if (!audio.paused) audio.play();
   }
   list.forEach((li, idx) => li.addEventListener('click', () => load(idx)));

--- a/style.css
+++ b/style.css
@@ -748,21 +748,50 @@ body.light #introCanvas { background: #eee; border-color: #87ceeb; }
 /* Custom audio player */
 .audio-player {
   display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 10px;
   margin-top: 20px;
   background: rgba(0, 0, 0, 0.2);
+  padding: 15px;
+  border-radius: 12px;
+  width: 280px;
+}
+.player-upper {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.1);
   padding: 10px;
   border-radius: 8px;
+  width: 100%;
+  justify-content: center;
+}
+.album-art {
+  width: 80px;
+  height: 80px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+.volume-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: center;
+}
+.lr-volume {
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 .audio-player canvas {
   background: rgba(0, 0, 0, 0.3);
   border-radius: 4px;
-  width: 300px;
+  width: 100%;
   height: 60px;
 }
 .progress-bar-audio {
-  width: 200px;
+  width: 100%;
   height: 8px;
   background: #355b35;
   border-radius: 4px;
@@ -804,6 +833,10 @@ body.light .progress-bar-audio { background: #b5d7b5; }
 }
 body.light .audio-player input[type=range] {
   background: #c8eac8;
+}
+.control-buttons {
+  display: flex;
+  gap: 10px;
 }
 body.light .audio-player input[type=range]::-webkit-slider-thumb {
   background: #5cbf5c;


### PR DESCRIPTION
## Summary
- redesign audio player to look like a compact MP3 player
- add album art and reorganize controls
- update playlist to include album images
- style the new player layout
- set album art dynamically from playlist

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ade397dd48327b6b41969db308f93