### PR TITLE
Add channel volume sliders to audio player

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,17 @@
         <button id="playPause">▶</button>
         <button id="nextTrack">⏭</button>
       </div>
+      <button id="volToggle" class="vol-toggle">🔊</button>
+      <div id="volLeft" class="vol-popup left">
+        <input id="volumeLeft" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
+        <label for="volumeLeft">L</label>
+        <input id="volumeMaster" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
+        <label for="volumeMaster">M</label>
+      </div>
+      <div id="volRight" class="vol-popup right">
+        <input id="volumeRight" type="range" min="0" max="1" step="0.01" value="1" orient="vertical">
+        <label for="volumeRight">R</label>
+      </div>
       <audio id="audio"></audio>
     </div>
     <h3 class="album-title">Track List</h3>

--- a/script.js
+++ b/script.js
@@ -1003,10 +1003,11 @@ if (audio) {
   const merger = ctx.createChannelMerger(2);
   const gainL = ctx.createGain();
   const gainR = ctx.createGain();
+  const gainMaster = ctx.createGain();
   source.connect(analyser);
   analyser.connect(gainL).connect(merger, 0, 0);
   analyser.connect(gainR).connect(merger, 0, 1);
-  merger.connect(ctx.destination);
+  merger.connect(gainMaster).connect(ctx.destination);
 
   function drawWave() {
     if (!waveCtx || !waveform) return;
@@ -1041,6 +1042,34 @@ if (audio) {
     const pct = (e.clientX - rect.left) / rect.width;
     audio.currentTime = pct * audio.duration;
   });
+
+  const volToggle = document.getElementById('volToggle');
+  const volLeft = document.getElementById('volLeft');
+  const volRight = document.getElementById('volRight');
+  const volLeftRange = document.getElementById('volumeLeft');
+  const volRightRange = document.getElementById('volumeRight');
+  const volMasterRange = document.getElementById('volumeMaster');
+  if (volToggle) {
+    volToggle.addEventListener('click', () => {
+      volLeft.classList.toggle('open');
+      volRight.classList.toggle('open');
+    });
+  }
+  if (volLeftRange) {
+    volLeftRange.addEventListener('input', () => {
+      gainL.gain.value = parseFloat(volLeftRange.value);
+    });
+  }
+  if (volRightRange) {
+    volRightRange.addEventListener('input', () => {
+      gainR.gain.value = parseFloat(volRightRange.value);
+    });
+  }
+  if (volMasterRange) {
+    volMasterRange.addEventListener('input', () => {
+      gainMaster.gain.value = parseFloat(volMasterRange.value);
+    });
+  }
 
 
   const soundSection = document.getElementById('sound');

--- a/style.css
+++ b/style.css
@@ -855,3 +855,40 @@ body.light .progress-bar-audio { background: #b5d7b5; }
   color: #3399ff;
 }
 .inventory .card:hover { background: #ddd; }
+
+/* volume control */
+.vol-toggle {
+  position: absolute;
+  top: 50%;
+  right: -28px;
+  transform: translateY(-50%);
+  background: #4caf50;
+  border: none;
+  color: #fff;
+  border-radius: 10px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.vol-popup {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%) scale(0);
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  padding: 8px 6px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transition: transform 0.3s;
+}
+.vol-popup.open { transform: translateY(-50%) scale(1); }
+.vol-popup.left { left: -50px; }
+.vol-popup.right { right: -50px; }
+.vol-popup input[type="range"] {
+  width: 8px;
+  height: 80px;
+  writing-mode: bt-lr;
+  -webkit-appearance: slider-vertical;
+}


### PR DESCRIPTION
## Summary
- create volume adjustment UI next to the audio player
- style popup sliders for left, right and master channels
- hook up gain nodes and JS handlers for volume control

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685aed76a5a0832783ce70bd89a4076d